### PR TITLE
Update pdf-export.md

### DIFF
--- a/pdf-export.md
+++ b/pdf-export.md
@@ -48,7 +48,7 @@ In order to enable the export to PDF in RadSpreadProcessing, you will need to ad
 
 # See Also
 
-* [Getting Started with Telerik Document Processing]({%slug getting-started%})
+* [Getting Started with Telerik Document Processing]({%slug radpdfprocessing-getting-started%})
 * [RadPdfProcessing]([%slug radpdfprocessing-overview%])
 * [RadWordsProcessing]([%slug radwordsprocessing-overview%])
 * [RadSpreadProcessing]([%slug radspreadprocessing-overview%])


### PR DESCRIPTION
Updated RadPdfProcessing Getting Started slug.

**Summary:**
The "Getting Started with Telerik Document Processing" slug brings you to the wrong location: **http://docs.telerik.com/devtools/document-processing/getting-started**

It should go to the following location instead: http://docs.telerik.com/devtools/document-processing/libraries/radpdfprocessing/getting-started


Note: I do not have a local jekyll running, so I have **not** confirmed this slug works. 