### PR TITLE
Added a warning on creating combo charts

### DIFF
--- a/libraries/radspreadprocessing/features/charts/using-charts.md
+++ b/libraries/radspreadprocessing/features/charts/using-charts.md
@@ -31,7 +31,8 @@ The FloatingChartShape class exposes the following constructors, which parse the
 	* *cellIndex*: The cell index where the top left corner of the shape is positioned.
 	* *chartDataRange*: The range containing the chart data.
 	* *seriesRangesOrientation*: A value indicating whether the series of the chart will refer to vertical or horizontal ranges or the direction will be determined automatically.
-	* *chartTypes*: The types of chart that will be created. Passing more than one type will create a combo chart.
+	* *chartTypes*: The types of chart that will be created. **Passing more than one type will create a combo chart.**
+> **WARNING**: The number of chartTypes must be no more than the number of columns inside the chartDataRange minus one (the first column is used to populate the X axis), otherwise you will get a exception of type **System.NullReferenceException**.
 
 Once you have created a FloatingChartShape, you can insert it in the document through the Add() method of worksheet's Shapes property.
 


### PR DESCRIPTION
I have bolded the the instruction on creating combo charts.
I have added an additional warning on creating a combo chart. I am not sure how it will look on the site as the Previewer does not render correctly. But it should be at least a note. Also I am not sure how the lone sentence between the to notes will look.