### PR TITLE
docs(common): add links to Blazor DPL resources

### DIFF
--- a/getting-started/Installation/installing-on-your-computer.md
+++ b/getting-started/Installation/installing-on-your-computer.md
@@ -36,6 +36,12 @@ When the installation completes, the Telerik Document Processing assemblies will
 
 When the installation completes, the Telerik Document Processing assemblies will be available in the *spreadsheet* sub-folder.
 
+## UI for Blazor
+
+[Download and Installation of Document Processing Libraries](https://docs.telerik.com/blazor-ui/common-features/document-processing)
+
+The libraries can be used through the available NuGet packages.
+
 ## UI for WPF
 
 [Installing Telerik UI for WPF](http://docs.telerik.com/devtools/wpf/installation-and-deployment/installing-telerik-ui-on-your-computer/installation-installing-which-file-do-i-need.html)

--- a/getting-started/explore-features.md
+++ b/getting-started/explore-features.md
@@ -23,6 +23,7 @@ The fastest way to get an overview of how you can implement Telerik Document Pro
 |[Telerik UI for ASP.NET AJAX](https://demos.telerik.com/aspnet-ajax/)|[Telerik UI for WPF](http://demos.telerik.com/wpf)|[Telerik UI for Xamarin](https://www.telerik.com/support/demos#mobile)|
 |[Telerik UI for ASP.NET MVC](https://demos.telerik.com/aspnet-mvc/)|[Telerik UI for WinForms](https://telerik-winforms-demos.s3.amazonaws.com/TelerikWinFormsExamplesLauncher.exe)||
 |[Telerik UI for ASP.NET Core](https://demos.telerik.com/aspnet-core/)|||
+|[Telerik UI for Blazor](https://demos.telerik.com/blazor-ui)|||
 |[Telerik UI for Silverlight](http://demos.telerik.com/silverlight/)|||
 
 ## Developer Focused Examples

--- a/getting-started/first-steps.md
+++ b/getting-started/first-steps.md
@@ -24,19 +24,22 @@ Telerik Document Processing is part of several Telerik bundles and is installed 
 1. UI for ASP.NET AJAX - [Installing Telerik UI for ASP.NET AJAX](http://docs.telerik.com/devtools/aspnet-ajax/installation/which-file-do-i-need-to-install). 
 When the installation completes, the Telerik Document Processing assemblies will be available in the *AdditionalLibraries* sub-folder.
 
-2. UI for ASP.NET MVC - [Installing Telerik UI for ASP.NET MVC](http://docs.telerik.com/kendo-ui/aspnet-mvc/introduction#installation). 
+1. UI for ASP.NET MVC - [Installing Telerik UI for ASP.NET MVC](http://docs.telerik.com/kendo-ui/aspnet-mvc/introduction#installation). 
 When the installation completes, the Telerik Document Processing assemblies will be available in the *AdditionalLibraries* sub-folder.
 
-3. UI for ASP.NET Core - [Installing Telerik UI for ASP.NET Core](https://docs.telerik.com/aspnet-core/getting-started/installation/document-processing). 
+1. UI for ASP.NET Core - [Installing Telerik UI for ASP.NET Core](https://docs.telerik.com/aspnet-core/getting-started/installation/document-processing). 
 The libraries can be used through the available NuGet packages.
 
-4. UI for WPF - [Installing Telerik UI for WPF](http://docs.telerik.com/devtools/wpf/installation-and-deployment/installing-telerik-ui-on-your-computer/installation-installing-which-file-do-i-need.html)
+1. UI for Blazor - [Installing Telerik UI for Blazor](https://docs.telerik.com/blazor-ui/common-features/document-processing). 
+The libraries can be used through the available NuGet packages.
 
-5. UI for Silverlight - [Installing Telerik UI for Silverlight](http://docs.telerik.com/devtools/silverlight/installation-and-deployment/installing-telerik-ui-on-your-computer/installation-installing-which-file-do-i-need.html)
+1. UI for WPF - [Installing Telerik UI for WPF](http://docs.telerik.com/devtools/wpf/installation-and-deployment/installing-telerik-ui-on-your-computer/installation-installing-which-file-do-i-need.html)
 
-6. UI for WinForms - [Installing Telerik UI for WinForms](http://docs.telerik.com/devtools/winforms/installation-deployment-and-distribution/installing-on-your-computer)
+1. UI for Silverlight - [Installing Telerik UI for Silverlight](http://docs.telerik.com/devtools/silverlight/installation-and-deployment/installing-telerik-ui-on-your-computer/installation-installing-which-file-do-i-need.html)
 
-7. UI for Xamarin - [Installing Telerik UI for Xamarin](https://docs.telerik.com/devtools/xamarin/installation-and-deployment/system-requirements)
+1. UI for WinForms - [Installing Telerik UI for WinForms](http://docs.telerik.com/devtools/winforms/installation-deployment-and-distribution/installing-on-your-computer)
+
+1. UI for Xamarin - [Installing Telerik UI for Xamarin](https://docs.telerik.com/devtools/xamarin/installation-and-deployment/system-requirements)
 
 ## Creating Application with Visual Studio
 

--- a/introduction.md
+++ b/introduction.md
@@ -23,7 +23,7 @@ Telerik Document Processing is a bundle of UI-independent, cross-platform librar
 * XLSX
 * ZIP
  
->**.NET Standard** and **.NET Core** compatible versions are available for the Telerik Document Processing libraries. Their assemblies can be downloaded from the **[UI for Xamarin](https://www.telerik.com/xamarin-ui)** and **[UI for ASP.NET Core](https://www.telerik.com/aspnet-core-ui)** suites respectively.
+>**.NET Standard** and **.NET Core** compatible versions are available for the Telerik Document Processing libraries. Their assemblies can be downloaded from the **[UI for Xamarin](https://www.telerik.com/xamarin-ui)**, **[UI for ASP.NET Core](https://www.telerik.com/aspnet-core-ui)** and **[UI for Blazor](https://www.telerik.com/blazor-ui)** suites respectively.
 
 >RadSpreadProcessing is the only one that is still available for the full .NET Framework only. Please, share your scenario and what features you would need from **SpreadProcessing for .NET Core** in the public item related to its implementation at [https://feedback.telerik.com/document-processing/1356226](https://feedback.telerik.com/document-processing/1356226).
 
@@ -44,7 +44,7 @@ Telerik Document Processing features the following components:
 
 ## Licensing
 
->Telerik Document Processing is available as part of **DevCraft**, **UI for ASP.NET Core**, **UI for ASP.NET MVC**, **UI for ASP.NET AJAX**, **UI for Xamarin**, **UI for WPF**, **UI for WinForms**, **UI for Silverlight**. A part of the libraries is included in  as well. The libraries are subject of the license under which you've obtained the assemblies.
+>Telerik Document Processing is available as part of **DevCraft**, **UI for ASP.NET Core**, **UI for ASP.NET MVC**, **UI for ASP.NET AJAX**, **UI for Blazor**, **UI for Xamarin**, **UI for WPF**, **UI for WinForms**, **UI for Silverlight**. A part of the libraries is included in  as well. The libraries are subject of the license under which you've obtained the assemblies.
 
 Learn more on how to start using Telerik Document Processing in the [Installing on Your Computer]({%slug installation-installing-on-your-computer%}) topic.
 


### PR DESCRIPTION
The DPL will be available in Blazor with our next release (planned for the 15 Jan 2019), so please don't put this live before that.

Could you also confirm if the following lists and descriptions are OK for .NET Core (which is what Blazor is based on):

* List of NuGet packages and what they do: https://github.com/telerik/blazor-docs/blob/master/common-features/document-processing.md#available-nuget-packages

* Some deeper links into your docs that I compiled a few years ago for AJAX, now I just copied over: https://github.com/telerik/blazor-docs/blob/master/common-features/document-processing.md#learning-resources

---------

I am also adding here a few issues I noticed:

There are missing images at https://docs.telerik.com/devtools/document-processing/getting-started/first-steps even though they are fine in a local build.

During a local build I get the following warnings that you may want to look into

```
Tab strip generation canceled for page: libraries/radspreadprocessing/features/format-codes.md. Missing 'region' or 'endregion' tag. Please check if the 'region' tag is properly closed.
regionStartCount: 0
regionEndCount: 1
```

and

```
    Liquid Warning: Liquid syntax error (line 41): Expected end_of_string but found id in "{{region radspreadprocessing-backward-compatibility_0}}" in libraries/radspreadprocessing/changes-and-backward-compatibility/backward-compatibility.md
    Liquid Warning: Liquid syntax error (line 23): Expected end_of_string but found id in "{{region radspreadstreamprocessing-export_0}}" in libraries/radspreadstreamprocessing/export.md
    Liquid Warning: Liquid syntax error (line 52): Expected end_of_string but found id in "{{region radspreadstreamprocessing-getting-started_0}}" in libraries/radspreadstreamprocessing/getting-started.md
    Liquid Warning: Liquid syntax error (line 136): Expected end_of_string but found id in "{{region radspreadprocessing-features-charts-working-with-series_4}}" in libraries/radspreadprocessing/features/charts/series.md
    Liquid Warning: Liquid syntax error (line 147): Expected end_of_string but found id in "{{region radspreadprocessing-features-charts-working-with-series_5}}" in libraries/radspreadprocessing/features/charts/series.md
    Liquid Warning: Liquid syntax error (line 159): Expected end_of_string but found id in "{{region radspreadprocessing-features-charts-working-with-series_6}}" in libraries/radspreadprocessing/features/charts/series.md
```