### PR TITLE
Fixed code snippet for removing rows and columns

### DIFF
--- a/libraries/radspreadprocessing/working-with-rows-and-columns/insert-and-remove.md
+++ b/libraries/radspreadprocessing/working-with-rows-and-columns/insert-and-remove.md
@@ -66,7 +66,7 @@ The __RowSelection__ class exposes a __Remove()__ method that performs the remov
 	int index = 2;
 	int itemCount = 3;
 	
-	RowSelection selection = worksheet.Rows[index, index + itemCount];
+	RowSelection selection = worksheet.Rows[index, index + itemCount - 1];
 	selection.Remove();
 {{endregion}}
 
@@ -115,7 +115,7 @@ The __ColumnSelection__ class exposes a __Remove()__ method that executes the re
 	int index = 2;
 	int itemCount = 3;
 	
-	ColumnSelection selection = worksheet.Columns[index, index + itemCount];
+	ColumnSelection selection = worksheet.Columns[index, index + itemCount - 1];
 	selection.Remove();
 {{endregion}}
 


### PR DESCRIPTION
int index = 2;
int itemCount = 3;
When this is defined, I would expect to remove 3 rows, starting with the row with index 2. With the initial version of the code, we remove the row with the index 2 and additionally remove 3 more rows, for a total of 4.
The same goes for the remove columns snippet.