### PR TITLE
Corrected the LoadImageFromUri sample

### DIFF
--- a/libraries/radwordsprocessing/formats-and-conversion/html/settings.md
+++ b/libraries/radwordsprocessing/formats-and-conversion/html/settings.md
@@ -65,8 +65,8 @@ __Example 1__ Shows how you can use the __LoadImageFromUri__ event to download a
 		System.Net.WebClient webClient = new System.Net.WebClient();
 		byte[] data = webClient.DownloadData(e.Uri);
 
-		// Pass the loaded data to the arguments 
-		string extension = e.Uri.Substring(e.Uri.Length - 3);
+		// Pass the loaded data to the arguments
+		string extension = System.IO.Path.GetExtension(e.Uri).Substring(1); // Get the extension without the dot
 		e.SetImageInfo(data, extension);
 	};
 


### PR DESCRIPTION
The old code will work only for files that have extensions with 3 characters:
string extension = e.Uri.Substring(e.Uri.Length - 3);
For *.jpeg it will return wrong value.