### PR TITLE
Flatten Form Fields - Check the Form Field Count

### DIFF
--- a/knowledge-base/flatten-form-fields.md
+++ b/knowledge-base/flatten-form-fields.md
@@ -40,6 +40,11 @@ This could be achieved by iterating the [RadFixedPage]({%slug radpdfprocessing-m
 
 	public static void FlattenFormFields(RadFixedDocument document)
 	{
+		if (document.AcroForm.FormFields.Count == 0)
+		{
+			return;
+		}
+		
 		foreach (RadFixedPage page in document.Pages)
 		{
 			List<Widget> widgetsToRemove = new List<Widget>();


### PR DESCRIPTION
Check to see if the RadFixedDocument contains any form fields at the beginning.