### PR TITLE
Clarified .NET Standard 5+ libraries to use

### DIFF
--- a/knowledge-base/import-export-save-load-workbook.md
+++ b/knowledge-base/import-export-save-load-workbook.md
@@ -201,7 +201,7 @@ public static byte[] ReadFileFromDatabaseAsByteArray(string id)
 
         using (var cmd = new SqlCommand() { Connection = cn, CommandText = statement })
         {
-            cmd.Parameters.AddWithValue("@id", fileName);
+            cmd.Parameters.AddWithValue("@id", id);
 
             cn.Open();
 

--- a/libraries/radspreadprocessing/getting-started.md
+++ b/libraries/radspreadprocessing/getting-started.md
@@ -1,3 +1,4 @@
+
 ---
 title: Getting Started
 page_title: Getting Started
@@ -25,7 +26,7 @@ This article will get you started in using the __RadSpreadProcessing__ library. 
 
 ## Assembly References
 
->The libraries support .NET 4 and later. .NET Standard-compatible binaries are available as well. The assemblies for .NET Standard don't include 'Windows' in their names. (e.g. **Telerik.Documents.Core.dll**). For more information check [**Cross-Platform Support**]({%slug radspreadprocessing-cross-platform%}) article.
+>The libraries support .NET 4 and later. Binaries compatible with .NET Standard/.NET 5+ are available as well. The assemblies for .NET Standard/.NET 5+ don't include 'Windows' in their names. (e.g. **Telerik.Documents.Core.dll**). However, both .NET Framework **and** .NET Standard/.Net 5+ class namespaces include "Windows" in their paths. For more information check [**Cross-Platform Support**]({%slug radspreadprocessing-cross-platform%}) article.
 
 In order to use the model of the __RadSpreadProcessing__ library in your project, you need to add references to the following assemblies:
 
@@ -33,7 +34,7 @@ In order to use the model of the __RadSpreadProcessing__ library in your project
 <thead>
 	<tr>
 		<th>.NET Framework </th>
-		<th>.NET Standard-compatible</th>
+		<th>.NET Standard/.NET 5+ compatible</th>
 		<th>Additional information</th>
 	</tr>
 </thead>


### PR DESCRIPTION
Added /.NET 5+ to the .NET Standard assembly headers' name and an elaboration on duplicate namespaces between both types of assemblies.
