### PR TITLE
Removed the TIFF library part from the comment about Telerik.Documents.ImageUtils.dll using Image Sharp.

### DIFF
--- a/libraries/radpdfprocessing/cross-platform.md
+++ b/libraries/radpdfprocessing/cross-platform.md
@@ -27,7 +27,7 @@ To export images different than Jpeg and Jpeg2000 or ImageQuality different than
 * **Telerik.Documents.ImageUtils.dll**
 <br><sub>_This assembly is not available in UI for Xamarin._</sub>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 **ImageSharp v.2.0.0** specifically is required.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
 

--- a/libraries/radpdfprocessing/cross-platform.md
+++ b/libraries/radpdfprocessing/cross-platform.md
@@ -27,7 +27,7 @@ To export images different than Jpeg and Jpeg2000 or ImageQuality different than
 * **Telerik.Documents.ImageUtils.dll**
 <br><sub>_This assembly is not available in UI for Xamarin._</sub>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 **ImageSharp v.2.0.0** specifically is required.
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
 

--- a/libraries/radpdfprocessing/cross-platform.md
+++ b/libraries/radpdfprocessing/cross-platform.md
@@ -92,6 +92,7 @@ The new **FixedExtensibilityManager** class is exposing the following properties
       
     >important If the JpegImageConverter property is not set, an exception is thrown.
     
+	>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
     The **Telerik.Documents.ImageUtils** assembly provides a default implementation of the JpegImageConverter class that could be used when exporting the document. The default implementation depends on the [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/) libraries to convert images to Jpeg format.
 
     >important Telerik.Documents.ImageUtils.dll is not available for Xamarin.

--- a/libraries/radpdfprocessing/getting-started.md
+++ b/libraries/radpdfprocessing/getting-started.md
@@ -82,7 +82,7 @@ In order to use the __RadPdfProcessing__ library in your project, you need to ad
 </tbody>
 </table>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 ## Creating a Document
 

--- a/libraries/radpdfprocessing/getting-started.md
+++ b/libraries/radpdfprocessing/getting-started.md
@@ -82,7 +82,7 @@ In order to use the __RadPdfProcessing__ library in your project, you need to ad
 </tbody>
 </table>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/).
 
 ## Creating a Document
 

--- a/libraries/radspreadprocessing/cross-platform-support/cross-platform.md
+++ b/libraries/radspreadprocessing/cross-platform-support/cross-platform.md
@@ -31,8 +31,7 @@ To use the model of **RadSpreadProcessing** in your cross-platform project, you 
 | **Telerik.Zip.dll**                      | Required for working with XSLX, XLS and PDF files. |
 | **Telerik.Documents.ImageUtils.dll** <br><sub>_This assembly is not available in UI for Xamarin._</sub> | Required when you need to export to PDF documents containing images different than **Jpeg** and **Jpeg2000** or **ImageQuality** different than High. |
 
-
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
 

--- a/libraries/radspreadprocessing/getting-started.md
+++ b/libraries/radspreadprocessing/getting-started.md
@@ -106,7 +106,7 @@ In order to use the model of the __RadSpreadProcessing__ library in your project
 </table>
 
 <sub> 
-	\* _Needed when exporting to PDF format a document containing images different than Jpeg and Jpeg2000 or ImageQuality different than High. The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/)._ 
+	\* _Needed when exporting to PDF format a document containing images different than Jpeg and Jpeg2000 or ImageQuality different than High. The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add а reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 </sub>
 
 ## Creating a Workbook

--- a/libraries/radwordsprocessing/cross-platform.md
+++ b/libraries/radwordsprocessing/cross-platform.md
@@ -60,7 +60,7 @@ In order to use the model of the **RadWordsProcessing** library in your cross-pl
 </tbody>
 </table>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
  

--- a/libraries/radwordsprocessing/getting-started.md
+++ b/libraries/radwordsprocessing/getting-started.md
@@ -100,7 +100,7 @@ Here is a list of assemblies that contain the __RadWordsProcessing__ functionali
 	\* _The Telerik.Documents.ImageUtils.dll assembly is needed when exporting to PDF format a document containing images different than **Jpeg** and **Jpeg2000** or **ImageQuality** different than High._
 </sub>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 ## Creating RadFlowDocument from Code
 


### PR DESCRIPTION
Removed the TIFF library part from the comment about Telerik.Documents.ImageUtils.dll using Image Sharp.