### PR TITLE
PdfProcessing: Add documentation for setting different permissions when exporting encrypted PDF document

### DIFF
--- a/libraries/radpdfprocessing/cross-platform.md
+++ b/libraries/radpdfprocessing/cross-platform.md
@@ -27,7 +27,7 @@ To export images different than Jpeg and Jpeg2000 or ImageQuality different than
 * **Telerik.Documents.ImageUtils.dll**
 <br><sub>_This assembly is not available in UI for Xamarin._</sub>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 **ImageSharp v.2.0.0** specifically is required.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
 

--- a/libraries/radpdfprocessing/cross-platform.md
+++ b/libraries/radpdfprocessing/cross-platform.md
@@ -27,7 +27,7 @@ To export images different than Jpeg and Jpeg2000 or ImageQuality different than
 * **Telerik.Documents.ImageUtils.dll**
 <br><sub>_This assembly is not available in UI for Xamarin._</sub>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 **ImageSharp v.2.0.0** specifically is required.
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
 

--- a/libraries/radpdfprocessing/cross-platform.md
+++ b/libraries/radpdfprocessing/cross-platform.md
@@ -92,6 +92,7 @@ The new **FixedExtensibilityManager** class is exposing the following properties
       
     >important If the JpegImageConverter property is not set, an exception is thrown.
     
+	>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
     The **Telerik.Documents.ImageUtils** assembly provides a default implementation of the JpegImageConverter class that could be used when exporting the document. The default implementation depends on the [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/) libraries to convert images to Jpeg format.
 
     >important Telerik.Documents.ImageUtils.dll is not available for Xamarin.

--- a/libraries/radpdfprocessing/formats-and-conversion/pdf/pdfformatprovider/settings.md
+++ b/libraries/radpdfprocessing/formats-and-conversion/pdf/pdfformatprovider/settings.md
@@ -48,7 +48,7 @@ __Example 1__ shows how you can create a __PdfImportSettings__ object and assign
 	PdfImportSettings settings = new PdfImportSettings();
 	settings.UserPasswordNeeded += (s, a) =>
 	{
-	    a.Password = "D0cum3ntP4ssw0rd";
+	    a.Password = "Us3rP4ssw0rd";
 	};
 	
 	provider.ImportSettings = settings;
@@ -70,6 +70,36 @@ This property specifies if the document should be encrypted. The default value i
 ### __UserPassword__
 
 The password to be used if the document is encrypted. The default password is an empty string.
+
+### __OwnerPassword__
+
+The password that governs permissions for operations such as printing, copying and modifying the document. The default password is an empty string.
+
+### __UserAccessPermissions__
+
+This property specifies three types of user access permissions: **PrintingPermissionType**, **ChangingPermissionType**, and **CopyingPermissionType**. Each has an available set of values, represented by the respective enumerations:
+
+
+* __PrintingPermissionType__: Sets the permissions for document printing. Possible values: 
+
+    * __None__: Specify no printing is allowed.
+    * __LowResolution__: Specify low resolution (150 dpi) printing is allowed.
+    * __HighResolution__: Specify printing on the highest resolution is allowed.
+
+* __ChangingPermissionType__: Sets the permissions for making changes to the document. Possible values: 
+
+    * __None__: Specify no document changes are allowed.
+    * __DocumentAssembly__: Specify inserting, deleting, and rotating page changes are allowed.
+    * __FormFieldFillingOrSigning__: Specify filling in form fields and signing existing signature fields changes are allowed.
+	* __FormFieldFillingOrSigningAndCommenting__: Specify commenting, filling in form fields, and signing existing signature fields changes are allowed.
+    * __AnyExceptExtractingPages__: Specify any changes except extracting pages are allowed.
+	
+* __CopyingPermissionType__: Sets the permissions for document copying. Possible values: 
+
+    * __None__: Specify no copying is allowed.
+    * __Copying__: Specify copying is allowed.
+    * __TextAccess__: Specify that text access for screen reader devices for copying is allowed.
+
 
 ### __ImageQuality__
 
@@ -101,6 +131,29 @@ __Example 2__ shows how you can create a __PdfExportSettings__ object and assign
 	settings.ImageQuality = ImageQuality.Medium;
 	settings.ComplianceLevel = PdfComplianceLevel.PdfA2B;
 	provider.ExportSettings = settings;
+
+{{endregion}}
+
+
+__Example 3__ shows how you can create a __PdfExportSettings__ object with a different set of settings. The settings used specify an OwnerPassword and UserAccessPermissions.
+
+
+#### __[C#] Example 3: Export settings__
+
+{{region cs-radpdfprocessing-formats-and-conversion-pdf-settings_1}}
+	PdfFormatProvider provider = new PdfFormatProvider();
+    PdfExportSettings settings = new PdfExportSettings();
+    settings.IsEncrypted = true;
+    settings.OwnerPassword = "0wn3rP4ssw0rd";
+    // The following permissions are exported only if the settings.IsEncrypted property is set to true
+    UserAccessPermissions permissions = new UserAccessPermissions
+    {
+    Printing = PrintingPermissionType.HighResolution,
+    Changing = ChangingPermissionType.AnyExceptExtractingPages,
+    Copying = CopyingPermissionType.TextAccess,
+    };
+    settings.UserAccessPermissions = permissions;
+    provider.ExportSettings = settings;
 
 {{endregion}}
 

--- a/libraries/radpdfprocessing/getting-started.md
+++ b/libraries/radpdfprocessing/getting-started.md
@@ -82,7 +82,7 @@ In order to use the __RadPdfProcessing__ library in your project, you need to ad
 </tbody>
 </table>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 ## Creating a Document
 

--- a/libraries/radpdfprocessing/getting-started.md
+++ b/libraries/radpdfprocessing/getting-started.md
@@ -82,7 +82,7 @@ In order to use the __RadPdfProcessing__ library in your project, you need to ad
 </tbody>
 </table>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/).
 
 ## Creating a Document
 

--- a/libraries/radspreadprocessing/cross-platform-support/cross-platform.md
+++ b/libraries/radspreadprocessing/cross-platform-support/cross-platform.md
@@ -31,8 +31,7 @@ To use the model of **RadSpreadProcessing** in your cross-platform project, you 
 | **Telerik.Zip.dll**                      | Required for working with XSLX, XLS and PDF files. |
 | **Telerik.Documents.ImageUtils.dll** <br><sub>_This assembly is not available in UI for Xamarin._</sub> | Required when you need to export to PDF documents containing images different than **Jpeg** and **Jpeg2000** or **ImageQuality** different than High. |
 
-
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
 

--- a/libraries/radspreadprocessing/getting-started.md
+++ b/libraries/radspreadprocessing/getting-started.md
@@ -106,7 +106,7 @@ In order to use the model of the __RadSpreadProcessing__ library in your project
 </table>
 
 <sub> 
-	\* _Needed when exporting to PDF format a document containing images different than Jpeg and Jpeg2000 or ImageQuality different than High. The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/)._ 
+	\* _Needed when exporting to PDF format a document containing images different than Jpeg and Jpeg2000 or ImageQuality different than High. The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add а reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 </sub>
 
 ## Creating a Workbook

--- a/libraries/radwordsprocessing/cross-platform.md
+++ b/libraries/radwordsprocessing/cross-platform.md
@@ -60,7 +60,7 @@ In order to use the model of the **RadWordsProcessing** library in your cross-pl
 </tbody>
 </table>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 > Note that for .NET Framework & .NET Core with Windows Compatibility Pack projects, the references contain "Windows" in their names (e.g. **Telerik.Windows.Documents.Core.dll**)
  

--- a/libraries/radwordsprocessing/getting-started.md
+++ b/libraries/radwordsprocessing/getting-started.md
@@ -100,7 +100,7 @@ Here is a list of assemblies that contain the __RadWordsProcessing__ functionali
 	\* _The Telerik.Documents.ImageUtils.dll assembly is needed when exporting to PDF format a document containing images different than **Jpeg** and **Jpeg2000** or **ImageQuality** different than High._
 </sub>
 
->note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp** and **TiffLibrary.ImageSharpAdapter**. In order to use this assembly, you will need to add references to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/) and [TiffLibrary.ImageSharpAdapter](https://www.nuget.org/packages/TiffLibrary.ImageSharpAdapter/).
+>note The **Telerik.Documents.ImageUtils.dll** assembly depends on **ImageSharp**. In order to use this assembly, you will need to add a reference to [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/). After R1 2022 SP1 the minimum **ImageSharp** required version is **v.2.0.0**.
 
 ## Creating RadFlowDocument from Code
 


### PR DESCRIPTION
PdfProcessing: Add documentation for setting different permissions when exporting encrypted PDF document in the PDFFormatProvider-Settings article