### PR TITLE
Updated example to use MagickFormatInfo.Create instead of TryGetImageFormat.

### DIFF
--- a/libraries/radpdfprocessing/cross-platform.md
+++ b/libraries/radpdfprocessing/cross-platform.md
@@ -110,33 +110,31 @@ The new **FixedExtensibilityManager** class is exposing the following properties
     
     #### **[C#] Example 4: Create a custom implementation inheriting the JpegImageConverterBase abstract class**
         {{region cs-radpdfprocessing-cross-platform_2}}
-    
+
             internal class CustomJpegImageConverter : Telerik.Windows.Documents.Extensibility.JpegImageConverterBase
             {
                 public override bool TryConvertToJpegImageData(byte[] imageData, ImageQuality imageQuality, out byte[] jpegImageData)
                 {
-                    string[] magickImageFormats = Enum.GetNames(typeof(MagickFormat)).Select(x => x.ToLower()).ToArray();
-                    string imageFormat;
-                    if (this.TryGetImageFormat(imageData, out imageFormat) && magickImageFormats.Contains(imageFormat.ToLower()))
+                    MagickFormatInfo formatInfo = MagickFormatInfo.Create(imageData);
+                    if (formatInfo != null && formatInfo.IsReadable)
                     {
                         using (MagickImage magickImage = new MagickImage(imageData))
                         {
-                            magickImage.Format = MagickFormat.Jpeg;
                             magickImage.Alpha(AlphaOption.Remove);
                             magickImage.Quality = (int)imageQuality;
-    
-                            jpegImageData = magickImage.ToByteArray();
+
+                            jpegImageData = magickImage.ToByteArray(MagickFormat.Jpeg);
                         }
-    
+
                         return true;
                     }
-    
+
                     jpegImageData = null;
                     return false;
                 }
             }
         {{endregion}}
-    
+
     #### **[C#] Example 5: Set the custom implementation to the JpegImageConverter property of the FixedExtensibilityManager**
         {{region cs-radpdfprocessing-cross-platform_3}}
     


### PR DESCRIPTION
This updates the example to use the new MagickFormatInfo.Create method that can be used to determine the image format.