### PR TITLE
Update create-custom-image-properties-resolver-net-standard.md

### DIFF
--- a/knowledge-base/create-custom-image-properties-resolver-net-standard.md
+++ b/knowledge-base/create-custom-image-properties-resolver-net-standard.md
@@ -63,41 +63,11 @@ The following code snippets demonstrates how to create a custom implementation o
         {
             try
             {
-                IImageFormat imageFormat;
-                using (ImageSharp image = ImageSharp.Load(imageData, out imageFormat))
+                using (Image image = Image.Load(imageData))
                 {
                     size = new Telerik.Documents.Primitives.Size(image.Width, image.Height);
 
-                    IImageDecoder decoder = null;
-                    Dictionary<Type, Action> decoderSwitch = new Dictionary<Type, Action>
-                        {
-                            { typeof(PngFormat), () => decoder = new PngDecoder() },
-                            { typeof(BmpFormat), () => decoder = new BmpDecoder() },
-                            { typeof(GifFormat), () => decoder = new GifDecoder() },
-                            { typeof(JpegFormat), () => decoder = new JpegDecoder() },
-                            { typeof(PbmFormat), () => decoder = new PbmDecoder() },
-                            { typeof(TgaFormat), () => decoder = new TgaDecoder() },
-                            { typeof(TiffFormat), () => decoder = new TiffDecoder() },
-                            { typeof(WebpFormat), () => decoder = new WebpDecoder() },
-                        };
-
-                    if (decoderSwitch.ContainsKey(imageFormat.GetType()))
-                    {
-                        decoderSwitch[imageFormat.GetType()]();
-                    }
-                    else
-                    {
-                        rawRgbData = null;
-                        rawAlpha = null;
-
-                        return false;
-                    }
-
-                    Configuration configuration = new Configuration();
-                    ImageSharp decodedImage = decoder.Decode(configuration, new MemoryStream(imageData));
-
-                    ImageFrame frame = decodedImage.Frames[0];
-
+                    var frame = image.Frames.RootFrame;
                     ImageFrame<Rgb24> frameRgb24 = frame as ImageFrame<Rgb24>;
                     if (frameRgb24 != null)
                     {


### PR DESCRIPTION
The TryGetRawImageData method is not working due to it trying to use features of the SixLabors.ImageSharp which are not available in the current version (it looks like they changed the decoders into static classes/methods so the new keyword is not working there). I've dropped in a version that works with SixLabors.ImageSharp version 3.1.4.