### PR TITLE
Update images.md

### DIFF
--- a/libraries/radpdfprocessing/cross-platform/images.md
+++ b/libraries/radpdfprocessing/cross-platform/images.md
@@ -42,9 +42,9 @@ In case you have specific requirements and the default ImagePropertiesResolver d
 
 1\. Inherit the `Telerik.Windows.Documents.Core.Imaging.ImagePropertiesResolverBase` class
    
-2.\. Implement its members
+2\. Implement its members
    
-3.\ Assign an instance of the custom implementation to the `FixedExtensibilityManager.ImagePropertiesResolver` property 
+3\. Assign an instance of the custom implementation to the `FixedExtensibilityManager.ImagePropertiesResolver` property 
 
 ## JpegImageConverter 
 

--- a/libraries/radpdfprocessing/cross-platform/images.md
+++ b/libraries/radpdfprocessing/cross-platform/images.md
@@ -40,8 +40,8 @@ PdfProcessing comes with a default implementation for such resolver called `Imag
 
 In case you have specific requirements and the default ImagePropertiesResolver doesn't fit them, you can implement custom logic that can handle them. To achieve that, you should:
 1. inherit the `Telerik.Windows.Documents.Core.Imaging.ImagePropertiesResolverBase` class
-1. implement its members
-1. assign an instance of the custom implementation to the `FixedExtensibilityManager.ImagePropertiesResolver` property 
+2. implement its members
+3. assign an instance of the custom implementation to the `FixedExtensibilityManager.ImagePropertiesResolver` property 
 
 ## JpegImageConverter 
 

--- a/libraries/radpdfprocessing/cross-platform/images.md
+++ b/libraries/radpdfprocessing/cross-platform/images.md
@@ -39,9 +39,12 @@ PdfProcessing comes with a default implementation for such resolver called `Imag
 ### Custom Implementation for ImagePropertiesResolver
 
 In case you have specific requirements and the default ImagePropertiesResolver doesn't fit them, you can implement custom logic that can handle them. To achieve that, you should:
-1. inherit the `Telerik.Windows.Documents.Core.Imaging.ImagePropertiesResolverBase` class
-2. implement its members
-3. assign an instance of the custom implementation to the `FixedExtensibilityManager.ImagePropertiesResolver` property 
+
+1\. Inherit the `Telerik.Windows.Documents.Core.Imaging.ImagePropertiesResolverBase` class
+   
+2.\. Implement its members
+   
+3.\ Assign an instance of the custom implementation to the `FixedExtensibilityManager.ImagePropertiesResolver` property 
 
 ## JpegImageConverter 
 


### PR DESCRIPTION
Even though having ordered lists all be "1." is valid markdown, it doesn't render correctly on the page.

https://docs.telerik.com/devtools/document-processing/libraries/radpdfprocessing/cross-platform/images#custom-implementation-for-imagepropertiesresolver

*This is most likely a larger issue that need to be solved another way, but this will work as a temporary solution*