### PR TITLE
Cross-Platform Font Discovery Is Documented Incorrectly

### DIFF
--- a/libraries/radpdfprocessing/concepts/fonts.md
+++ b/libraries/radpdfprocessing/concepts/fonts.md
@@ -18,7 +18,7 @@ position: 5
 
 >note Starting with **Q2 2024** RadPdfProcessing offers support for OTF (OpenType Font) font file format.
 
->important In **.NET Standard/.NET (Target OS: None)** environments, fonts beyond the [14 standard ones]({%slug radpdfprocessing-concepts-fonts%}#standard-fonts) require a [FontsProvider implementation]({%slug pdfprocessing-implement-fontsprovider%}) to be resolved correctly.
+>important In **.NET Standard/.NET (Target OS: None)** environments, the cross-platform system-font provider can resolve fonts beyond the [14 standard ones]({%slug radpdfprocessing-concepts-fonts%}#standard-fonts) when the fonts are installed in a supported system directory. Use a [FontsProvider implementation]({%slug pdfprocessing-implement-fontsprovider%}) for fonts that are not installed in those directories or when you need explicit, repeatable font deployment.
 
 ## Supported Font Types
 

--- a/libraries/radpdfprocessing/cross-platform/fonts.md
+++ b/libraries/radpdfprocessing/cross-platform/fonts.md
@@ -11,17 +11,33 @@ position: 1
 
 # Fonts
 
-Unlike the .NET Framework and .NET (Target OS: *Windows*) version, the RadPdfProcessing **.NET Standard** and **.NET (Target OS: *None*)** version does not offer a default mechanism for reading fonts. The `FixedExtensibilityManager` class is exposed to help you implement this functionality.
+RadPdfProcessing automatically discovers installed system fonts in cross-platform **.NET Standard** and **.NET (Target OS: *None*)** applications. The `FixedExtensibilityManager` class also lets you provide font data explicitly when your application needs fonts that are not installed on the host system.
 
 ## Setting and Exporting Fonts
 
-RadPdfProcessing needs access to the font data so that it can read it and add it to the PDF file. To allow the library to create and use fonts, provide an implementation of the `FontsProviderBase` abstract class and set this implementation to the `FontsProvider` property of the `FixedExtensibilityManager`.
+RadPdfProcessing loads font data when it creates text and exports a PDF. On cross-platform targets, the first access to `FixedExtensibilityManager.FontsProvider` automatically activates the system-font provider. You do not need to register a provider for fonts that are installed in a supported system font directory.
 
-You can find a detailed `FixedExtensibilityManager` and `FontsProvider` description and implementation in the [How to implement a FontsProvider]({%slug pdfprocessing-implement-fontsprovider%}) article.
+The system-font provider searches the following locations. The provider scans directories recursively and uses supported `.ttf`, `.otf`, and `.ttc` files that it can access and parse.
 
->important If the `FontsProvider` property is not set, a default font is used when exporting the document in cross-platform applications.
+| Platform | Default font locations |
+|---|---|
+| Windows | The Windows `Fonts` directory and the current user's `Microsoft\Windows\Fonts` directory. |
+| Linux | `/usr/share/fonts`, `/usr/local/share/fonts`, `/var/lib/flatpak/exports/share/fonts`, the user's `~/.fonts` directory, and the user's `~/.local/share/fonts` directory. |
+| macOS | `/System/Library/Fonts`, `/Library/Fonts`, and the current user's `~/Library/Fonts` directory. |
+| iOS | `/System/Library/Fonts` and `/Library/Fonts`. |
+| Android | `/system/fonts`, `/system/product/fonts`, and `/product/fonts`. |
 
->important When converting a document (for example, DOCX, HTML) to PDF format in **.NET Standard** and **.NET (Target OS: *None*)** projects, fonts from the original document are not automatically maintained in the PDF unless you explicitly provide the font data. This is especially important when the original document uses non-standard or custom fonts. The PdfProcessing library requires access to the actual font files to embed them in the PDF. If font data is not provided, the PDF model substitutes the missing fonts with standard ones, resulting in a mismatch between the original document and the exported PDF file.
+The provider builds its font index lazily. If a directory does not exist, a font file is inaccessible, a file is larger than 50 MB, or a font file is corrupted or unsupported, the provider skips that item. The provider returns no data for a font family that is not found, so the resulting document can use font substitution according to the PDF and application settings.
+
+When you assign a custom provider to `FixedExtensibilityManager.FontsProvider`, the custom provider takes precedence. Use a custom provider when you need to:
+
+* Bundle fonts with your application instead of relying on fonts installed on the host system.
+* Use fonts stored in an application-specific location or another data source.
+* Control font resolution for repeatable output across machines, containers, or mobile devices.
+
+You can find a detailed `FixedExtensibilityManager` and `FontsProvider` implementation in the [How to implement a FontsProvider]({%slug pdfprocessing-implement-fontsprovider%}) article.
+
+>important When converting a document (for example, DOCX or HTML) to PDF format, the system-font provider can resolve a font only when the matching font is installed in a directory that the provider searches. Fonts embedded in the source document, fonts stored in another application location, and custom fonts that are not installed require a custom provider that returns the font data. If the requested font cannot be resolved, the PDF model can substitute another font, which may change the document's appearance or text layout.
 
 ## Implementing a FontsProviderBase
 


### PR DESCRIPTION
Priority: Critical  
Confidence: 10

Missing Functionality: The implementation automatically installs `SystemFontsFontsProvider` when no custom provider is configured. It discovers fonts across Windows, Linux, macOS, iOS, and Android.

Evidence Found in Code:

- `Documents/Fixed/Core/Extensibility/FixedExtensibilityManager.cs`
- `Documents/Fixed/Core/Extensibility/SystemFontsFontsProvider.cs`

Current Documentation Status: Outdated. The cross-platform font documentation implies that applications must always provide a custom font provider.

Recommended Documentation: Explain automatic system-font discovery, supported platforms, discovery paths, fallback behavior, and when an application still needs a custom provider.

Business/User Impact: Users may add unnecessary configuration or believe cross-platform PDF generation is unsupported without custom font code.

Confidence Score: 10